### PR TITLE
Add Transaction, Money, and Category proto definitions

### DIFF
--- a/services/transaction/gen/go/transaction.pb.go
+++ b/services/transaction/gen/go/transaction.pb.go
@@ -9,6 +9,7 @@ package transactionv1
 import (
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
@@ -20,6 +21,104 @@ const (
 	// Verify that runtime/protoimpl is sufficiently up-to-date.
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
+
+// Category represents the category of a transaction
+type Category int32
+
+const (
+	Category_CATEGORY_UNSPECIFIED         Category = 0
+	Category_CATEGORY_INCOME              Category = 1  // Income
+	Category_CATEGORY_FOOD                Category = 2  // Food
+	Category_CATEGORY_DAILY_NECESSITIES   Category = 3  // Daily necessities
+	Category_CATEGORY_HOBBY               Category = 4  // Hobby & Entertainment
+	Category_CATEGORY_SOCIAL              Category = 5  // Social expenses
+	Category_CATEGORY_TRANSPORTATION      Category = 6  // Transportation
+	Category_CATEGORY_CLOTHING            Category = 7  // Clothing & Beauty
+	Category_CATEGORY_HEALTH              Category = 8  // Health & Medical
+	Category_CATEGORY_AUTOMOBILE          Category = 9  // Automobile
+	Category_CATEGORY_EDUCATION           Category = 10 // Education
+	Category_CATEGORY_SPECIAL             Category = 11 // Special expenses
+	Category_CATEGORY_CASH_CARD           Category = 12 // Cash & Card
+	Category_CATEGORY_UTILITIES           Category = 13 // Utilities
+	Category_CATEGORY_COMMUNICATION       Category = 14 // Communication
+	Category_CATEGORY_HOUSING             Category = 15 // Housing
+	Category_CATEGORY_TAX_SOCIAL_SECURITY Category = 16 // Tax & Social security
+	Category_CATEGORY_INSURANCE           Category = 17 // Insurance
+	Category_CATEGORY_OTHER               Category = 18 // Other
+)
+
+// Enum value maps for Category.
+var (
+	Category_name = map[int32]string{
+		0:  "CATEGORY_UNSPECIFIED",
+		1:  "CATEGORY_INCOME",
+		2:  "CATEGORY_FOOD",
+		3:  "CATEGORY_DAILY_NECESSITIES",
+		4:  "CATEGORY_HOBBY",
+		5:  "CATEGORY_SOCIAL",
+		6:  "CATEGORY_TRANSPORTATION",
+		7:  "CATEGORY_CLOTHING",
+		8:  "CATEGORY_HEALTH",
+		9:  "CATEGORY_AUTOMOBILE",
+		10: "CATEGORY_EDUCATION",
+		11: "CATEGORY_SPECIAL",
+		12: "CATEGORY_CASH_CARD",
+		13: "CATEGORY_UTILITIES",
+		14: "CATEGORY_COMMUNICATION",
+		15: "CATEGORY_HOUSING",
+		16: "CATEGORY_TAX_SOCIAL_SECURITY",
+		17: "CATEGORY_INSURANCE",
+		18: "CATEGORY_OTHER",
+	}
+	Category_value = map[string]int32{
+		"CATEGORY_UNSPECIFIED":         0,
+		"CATEGORY_INCOME":              1,
+		"CATEGORY_FOOD":                2,
+		"CATEGORY_DAILY_NECESSITIES":   3,
+		"CATEGORY_HOBBY":               4,
+		"CATEGORY_SOCIAL":              5,
+		"CATEGORY_TRANSPORTATION":      6,
+		"CATEGORY_CLOTHING":            7,
+		"CATEGORY_HEALTH":              8,
+		"CATEGORY_AUTOMOBILE":          9,
+		"CATEGORY_EDUCATION":           10,
+		"CATEGORY_SPECIAL":             11,
+		"CATEGORY_CASH_CARD":           12,
+		"CATEGORY_UTILITIES":           13,
+		"CATEGORY_COMMUNICATION":       14,
+		"CATEGORY_HOUSING":             15,
+		"CATEGORY_TAX_SOCIAL_SECURITY": 16,
+		"CATEGORY_INSURANCE":           17,
+		"CATEGORY_OTHER":               18,
+	}
+)
+
+func (x Category) Enum() *Category {
+	p := new(Category)
+	*p = x
+	return p
+}
+
+func (x Category) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (Category) Descriptor() protoreflect.EnumDescriptor {
+	return file_transaction_proto_enumTypes[0].Descriptor()
+}
+
+func (Category) Type() protoreflect.EnumType {
+	return &file_transaction_proto_enumTypes[0]
+}
+
+func (x Category) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use Category.Descriptor instead.
+func (Category) EnumDescriptor() ([]byte, []int) {
+	return file_transaction_proto_rawDescGZIP(), []int{0}
+}
 
 type HealthCheckResponse_ServingStatus int32
 
@@ -57,11 +156,11 @@ func (x HealthCheckResponse_ServingStatus) String() string {
 }
 
 func (HealthCheckResponse_ServingStatus) Descriptor() protoreflect.EnumDescriptor {
-	return file_transaction_proto_enumTypes[0].Descriptor()
+	return file_transaction_proto_enumTypes[1].Descriptor()
 }
 
 func (HealthCheckResponse_ServingStatus) Type() protoreflect.EnumType {
-	return &file_transaction_proto_enumTypes[0]
+	return &file_transaction_proto_enumTypes[1]
 }
 
 func (x HealthCheckResponse_ServingStatus) Number() protoreflect.EnumNumber {
@@ -70,7 +169,229 @@ func (x HealthCheckResponse_ServingStatus) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use HealthCheckResponse_ServingStatus.Descriptor instead.
 func (HealthCheckResponse_ServingStatus) EnumDescriptor() ([]byte, []int) {
-	return file_transaction_proto_rawDescGZIP(), []int{1, 0}
+	return file_transaction_proto_rawDescGZIP(), []int{5, 0}
+}
+
+// Money represents an amount of money with currency-agnostic precision
+type Money struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The whole units of the amount
+	Units int64 `protobuf:"varint,1,opt,name=units,proto3" json:"units,omitempty"`
+	// Number of nano units of the amount (10^-9)
+	// Must be between -999,999,999 and +999,999,999 inclusive
+	// Sign must match units (both positive, both negative, or both zero)
+	Nanos         int32 `protobuf:"varint,2,opt,name=nanos,proto3" json:"nanos,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *Money) Reset() {
+	*x = Money{}
+	mi := &file_transaction_proto_msgTypes[0]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Money) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Money) ProtoMessage() {}
+
+func (x *Money) ProtoReflect() protoreflect.Message {
+	mi := &file_transaction_proto_msgTypes[0]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Money.ProtoReflect.Descriptor instead.
+func (*Money) Descriptor() ([]byte, []int) {
+	return file_transaction_proto_rawDescGZIP(), []int{0}
+}
+
+func (x *Money) GetUnits() int64 {
+	if x != nil {
+		return x.Units
+	}
+	return 0
+}
+
+func (x *Money) GetNanos() int32 {
+	if x != nil {
+		return x.Nanos
+	}
+	return 0
+}
+
+// Transaction represents a single financial transaction
+type Transaction struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Unique identifier for the transaction
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	// Date of the transaction
+	Date *timestamppb.Timestamp `protobuf:"bytes,2,opt,name=date,proto3" json:"date,omitempty"`
+	// Title or description of the transaction
+	Title string `protobuf:"bytes,3,opt,name=title,proto3" json:"title,omitempty"`
+	// Amount of the transaction (negative for expenses, positive for income)
+	Amount *Money `protobuf:"bytes,4,opt,name=amount,proto3" json:"amount,omitempty"`
+	// Category of the transaction
+	Category      Category `protobuf:"varint,5,opt,name=category,proto3,enum=transaction.v1.Category" json:"category,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *Transaction) Reset() {
+	*x = Transaction{}
+	mi := &file_transaction_proto_msgTypes[1]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Transaction) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Transaction) ProtoMessage() {}
+
+func (x *Transaction) ProtoReflect() protoreflect.Message {
+	mi := &file_transaction_proto_msgTypes[1]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Transaction.ProtoReflect.Descriptor instead.
+func (*Transaction) Descriptor() ([]byte, []int) {
+	return file_transaction_proto_rawDescGZIP(), []int{1}
+}
+
+func (x *Transaction) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *Transaction) GetDate() *timestamppb.Timestamp {
+	if x != nil {
+		return x.Date
+	}
+	return nil
+}
+
+func (x *Transaction) GetTitle() string {
+	if x != nil {
+		return x.Title
+	}
+	return ""
+}
+
+func (x *Transaction) GetAmount() *Money {
+	if x != nil {
+		return x.Amount
+	}
+	return nil
+}
+
+func (x *Transaction) GetCategory() Category {
+	if x != nil {
+		return x.Category
+	}
+	return Category_CATEGORY_UNSPECIFIED
+}
+
+// ListTransactionsRequest is the request for listing transactions
+type ListTransactionsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListTransactionsRequest) Reset() {
+	*x = ListTransactionsRequest{}
+	mi := &file_transaction_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListTransactionsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListTransactionsRequest) ProtoMessage() {}
+
+func (x *ListTransactionsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_transaction_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListTransactionsRequest.ProtoReflect.Descriptor instead.
+func (*ListTransactionsRequest) Descriptor() ([]byte, []int) {
+	return file_transaction_proto_rawDescGZIP(), []int{2}
+}
+
+// ListTransactionsResponse is the response for listing transactions
+type ListTransactionsResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// List of transactions
+	Transactions  []*Transaction `protobuf:"bytes,1,rep,name=transactions,proto3" json:"transactions,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListTransactionsResponse) Reset() {
+	*x = ListTransactionsResponse{}
+	mi := &file_transaction_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListTransactionsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListTransactionsResponse) ProtoMessage() {}
+
+func (x *ListTransactionsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_transaction_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListTransactionsResponse.ProtoReflect.Descriptor instead.
+func (*ListTransactionsResponse) Descriptor() ([]byte, []int) {
+	return file_transaction_proto_rawDescGZIP(), []int{3}
+}
+
+func (x *ListTransactionsResponse) GetTransactions() []*Transaction {
+	if x != nil {
+		return x.Transactions
+	}
+	return nil
 }
 
 // HealthCheckRequest is the request for health check
@@ -83,7 +404,7 @@ type HealthCheckRequest struct {
 
 func (x *HealthCheckRequest) Reset() {
 	*x = HealthCheckRequest{}
-	mi := &file_transaction_proto_msgTypes[0]
+	mi := &file_transaction_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -95,7 +416,7 @@ func (x *HealthCheckRequest) String() string {
 func (*HealthCheckRequest) ProtoMessage() {}
 
 func (x *HealthCheckRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_transaction_proto_msgTypes[0]
+	mi := &file_transaction_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -108,7 +429,7 @@ func (x *HealthCheckRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HealthCheckRequest.ProtoReflect.Descriptor instead.
 func (*HealthCheckRequest) Descriptor() ([]byte, []int) {
-	return file_transaction_proto_rawDescGZIP(), []int{0}
+	return file_transaction_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *HealthCheckRequest) GetService() string {
@@ -128,7 +449,7 @@ type HealthCheckResponse struct {
 
 func (x *HealthCheckResponse) Reset() {
 	*x = HealthCheckResponse{}
-	mi := &file_transaction_proto_msgTypes[1]
+	mi := &file_transaction_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -140,7 +461,7 @@ func (x *HealthCheckResponse) String() string {
 func (*HealthCheckResponse) ProtoMessage() {}
 
 func (x *HealthCheckResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_transaction_proto_msgTypes[1]
+	mi := &file_transaction_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -153,7 +474,7 @@ func (x *HealthCheckResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HealthCheckResponse.ProtoReflect.Descriptor instead.
 func (*HealthCheckResponse) Descriptor() ([]byte, []int) {
-	return file_transaction_proto_rawDescGZIP(), []int{1}
+	return file_transaction_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *HealthCheckResponse) GetStatus() HealthCheckResponse_ServingStatus {
@@ -167,7 +488,19 @@ var File_transaction_proto protoreflect.FileDescriptor
 
 const file_transaction_proto_rawDesc = "" +
 	"\n" +
-	"\x11transaction.proto\x12\x0etransaction.v1\".\n" +
+	"\x11transaction.proto\x12\x0etransaction.v1\x1a\x1fgoogle/protobuf/timestamp.proto\"3\n" +
+	"\x05Money\x12\x14\n" +
+	"\x05units\x18\x01 \x01(\x03R\x05units\x12\x14\n" +
+	"\x05nanos\x18\x02 \x01(\x05R\x05nanos\"\xc8\x01\n" +
+	"\vTransaction\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12.\n" +
+	"\x04date\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\x04date\x12\x14\n" +
+	"\x05title\x18\x03 \x01(\tR\x05title\x12-\n" +
+	"\x06amount\x18\x04 \x01(\v2\x15.transaction.v1.MoneyR\x06amount\x124\n" +
+	"\bcategory\x18\x05 \x01(\x0e2\x18.transaction.v1.CategoryR\bcategory\"\x19\n" +
+	"\x17ListTransactionsRequest\"[\n" +
+	"\x18ListTransactionsResponse\x12?\n" +
+	"\ftransactions\x18\x01 \x03(\v2\x1b.transaction.v1.TransactionR\ftransactions\".\n" +
 	"\x12HealthCheckRequest\x12\x18\n" +
 	"\aservice\x18\x01 \x01(\tR\aservice\"\xb1\x01\n" +
 	"\x13HealthCheckResponse\x12I\n" +
@@ -176,9 +509,31 @@ const file_transaction_proto_rawDesc = "" +
 	"\aUNKNOWN\x10\x00\x12\v\n" +
 	"\aSERVING\x10\x01\x12\x0f\n" +
 	"\vNOT_SERVING\x10\x02\x12\x13\n" +
-	"\x0fSERVICE_UNKNOWN\x10\x032l\n" +
+	"\x0fSERVICE_UNKNOWN\x10\x03*\xd5\x03\n" +
+	"\bCategory\x12\x18\n" +
+	"\x14CATEGORY_UNSPECIFIED\x10\x00\x12\x13\n" +
+	"\x0fCATEGORY_INCOME\x10\x01\x12\x11\n" +
+	"\rCATEGORY_FOOD\x10\x02\x12\x1e\n" +
+	"\x1aCATEGORY_DAILY_NECESSITIES\x10\x03\x12\x12\n" +
+	"\x0eCATEGORY_HOBBY\x10\x04\x12\x13\n" +
+	"\x0fCATEGORY_SOCIAL\x10\x05\x12\x1b\n" +
+	"\x17CATEGORY_TRANSPORTATION\x10\x06\x12\x15\n" +
+	"\x11CATEGORY_CLOTHING\x10\a\x12\x13\n" +
+	"\x0fCATEGORY_HEALTH\x10\b\x12\x17\n" +
+	"\x13CATEGORY_AUTOMOBILE\x10\t\x12\x16\n" +
+	"\x12CATEGORY_EDUCATION\x10\n" +
+	"\x12\x14\n" +
+	"\x10CATEGORY_SPECIAL\x10\v\x12\x16\n" +
+	"\x12CATEGORY_CASH_CARD\x10\f\x12\x16\n" +
+	"\x12CATEGORY_UTILITIES\x10\r\x12\x1a\n" +
+	"\x16CATEGORY_COMMUNICATION\x10\x0e\x12\x14\n" +
+	"\x10CATEGORY_HOUSING\x10\x0f\x12 \n" +
+	"\x1cCATEGORY_TAX_SOCIAL_SECURITY\x10\x10\x12\x16\n" +
+	"\x12CATEGORY_INSURANCE\x10\x11\x12\x12\n" +
+	"\x0eCATEGORY_OTHER\x10\x122\xd3\x01\n" +
 	"\x12TransactionService\x12V\n" +
-	"\vHealthCheck\x12\".transaction.v1.HealthCheckRequest\x1a#.transaction.v1.HealthCheckResponseB\xc5\x01\n" +
+	"\vHealthCheck\x12\".transaction.v1.HealthCheckRequest\x1a#.transaction.v1.HealthCheckResponse\x12e\n" +
+	"\x10ListTransactions\x12'.transaction.v1.ListTransactionsRequest\x1a(.transaction.v1.ListTransactionsResponseB\xc5\x01\n" +
 	"\x12com.transaction.v1B\x10TransactionProtoP\x01ZDgithub.com/boykush/foresee/services/transaction/gen/go;transactionv1\xa2\x02\x03TXX\xaa\x02\x0eTransaction.V1\xca\x02\x0eTransaction\\V1\xe2\x02\x1aTransaction\\V1\\GPBMetadata\xea\x02\x0fTransaction::V1b\x06proto3"
 
 var (
@@ -193,22 +548,34 @@ func file_transaction_proto_rawDescGZIP() []byte {
 	return file_transaction_proto_rawDescData
 }
 
-var file_transaction_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_transaction_proto_msgTypes = make([]protoimpl.MessageInfo, 2)
+var file_transaction_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
+var file_transaction_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
 var file_transaction_proto_goTypes = []any{
-	(HealthCheckResponse_ServingStatus)(0), // 0: transaction.v1.HealthCheckResponse.ServingStatus
-	(*HealthCheckRequest)(nil),             // 1: transaction.v1.HealthCheckRequest
-	(*HealthCheckResponse)(nil),            // 2: transaction.v1.HealthCheckResponse
+	(Category)(0),                          // 0: transaction.v1.Category
+	(HealthCheckResponse_ServingStatus)(0), // 1: transaction.v1.HealthCheckResponse.ServingStatus
+	(*Money)(nil),                          // 2: transaction.v1.Money
+	(*Transaction)(nil),                    // 3: transaction.v1.Transaction
+	(*ListTransactionsRequest)(nil),        // 4: transaction.v1.ListTransactionsRequest
+	(*ListTransactionsResponse)(nil),       // 5: transaction.v1.ListTransactionsResponse
+	(*HealthCheckRequest)(nil),             // 6: transaction.v1.HealthCheckRequest
+	(*HealthCheckResponse)(nil),            // 7: transaction.v1.HealthCheckResponse
+	(*timestamppb.Timestamp)(nil),          // 8: google.protobuf.Timestamp
 }
 var file_transaction_proto_depIdxs = []int32{
-	0, // 0: transaction.v1.HealthCheckResponse.status:type_name -> transaction.v1.HealthCheckResponse.ServingStatus
-	1, // 1: transaction.v1.TransactionService.HealthCheck:input_type -> transaction.v1.HealthCheckRequest
-	2, // 2: transaction.v1.TransactionService.HealthCheck:output_type -> transaction.v1.HealthCheckResponse
-	2, // [2:3] is the sub-list for method output_type
-	1, // [1:2] is the sub-list for method input_type
-	1, // [1:1] is the sub-list for extension type_name
-	1, // [1:1] is the sub-list for extension extendee
-	0, // [0:1] is the sub-list for field type_name
+	8, // 0: transaction.v1.Transaction.date:type_name -> google.protobuf.Timestamp
+	2, // 1: transaction.v1.Transaction.amount:type_name -> transaction.v1.Money
+	0, // 2: transaction.v1.Transaction.category:type_name -> transaction.v1.Category
+	3, // 3: transaction.v1.ListTransactionsResponse.transactions:type_name -> transaction.v1.Transaction
+	1, // 4: transaction.v1.HealthCheckResponse.status:type_name -> transaction.v1.HealthCheckResponse.ServingStatus
+	6, // 5: transaction.v1.TransactionService.HealthCheck:input_type -> transaction.v1.HealthCheckRequest
+	4, // 6: transaction.v1.TransactionService.ListTransactions:input_type -> transaction.v1.ListTransactionsRequest
+	7, // 7: transaction.v1.TransactionService.HealthCheck:output_type -> transaction.v1.HealthCheckResponse
+	5, // 8: transaction.v1.TransactionService.ListTransactions:output_type -> transaction.v1.ListTransactionsResponse
+	7, // [7:9] is the sub-list for method output_type
+	5, // [5:7] is the sub-list for method input_type
+	5, // [5:5] is the sub-list for extension type_name
+	5, // [5:5] is the sub-list for extension extendee
+	0, // [0:5] is the sub-list for field type_name
 }
 
 func init() { file_transaction_proto_init() }
@@ -221,8 +588,8 @@ func file_transaction_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_transaction_proto_rawDesc), len(file_transaction_proto_rawDesc)),
-			NumEnums:      1,
-			NumMessages:   2,
+			NumEnums:      2,
+			NumMessages:   6,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/services/transaction/gen/go/transaction_grpc.pb.go
+++ b/services/transaction/gen/go/transaction_grpc.pb.go
@@ -19,7 +19,8 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	TransactionService_HealthCheck_FullMethodName = "/transaction.v1.TransactionService/HealthCheck"
+	TransactionService_HealthCheck_FullMethodName      = "/transaction.v1.TransactionService/HealthCheck"
+	TransactionService_ListTransactions_FullMethodName = "/transaction.v1.TransactionService/ListTransactions"
 )
 
 // TransactionServiceClient is the client API for TransactionService service.
@@ -30,6 +31,8 @@ const (
 type TransactionServiceClient interface {
 	// HealthCheck checks if the service is healthy
 	HealthCheck(ctx context.Context, in *HealthCheckRequest, opts ...grpc.CallOption) (*HealthCheckResponse, error)
+	// ListTransactions returns a list of all transactions
+	ListTransactions(ctx context.Context, in *ListTransactionsRequest, opts ...grpc.CallOption) (*ListTransactionsResponse, error)
 }
 
 type transactionServiceClient struct {
@@ -50,6 +53,16 @@ func (c *transactionServiceClient) HealthCheck(ctx context.Context, in *HealthCh
 	return out, nil
 }
 
+func (c *transactionServiceClient) ListTransactions(ctx context.Context, in *ListTransactionsRequest, opts ...grpc.CallOption) (*ListTransactionsResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ListTransactionsResponse)
+	err := c.cc.Invoke(ctx, TransactionService_ListTransactions_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // TransactionServiceServer is the server API for TransactionService service.
 // All implementations must embed UnimplementedTransactionServiceServer
 // for forward compatibility.
@@ -58,6 +71,8 @@ func (c *transactionServiceClient) HealthCheck(ctx context.Context, in *HealthCh
 type TransactionServiceServer interface {
 	// HealthCheck checks if the service is healthy
 	HealthCheck(context.Context, *HealthCheckRequest) (*HealthCheckResponse, error)
+	// ListTransactions returns a list of all transactions
+	ListTransactions(context.Context, *ListTransactionsRequest) (*ListTransactionsResponse, error)
 	mustEmbedUnimplementedTransactionServiceServer()
 }
 
@@ -70,6 +85,9 @@ type UnimplementedTransactionServiceServer struct{}
 
 func (UnimplementedTransactionServiceServer) HealthCheck(context.Context, *HealthCheckRequest) (*HealthCheckResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method HealthCheck not implemented")
+}
+func (UnimplementedTransactionServiceServer) ListTransactions(context.Context, *ListTransactionsRequest) (*ListTransactionsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ListTransactions not implemented")
 }
 func (UnimplementedTransactionServiceServer) mustEmbedUnimplementedTransactionServiceServer() {}
 func (UnimplementedTransactionServiceServer) testEmbeddedByValue()                            {}
@@ -110,6 +128,24 @@ func _TransactionService_HealthCheck_Handler(srv interface{}, ctx context.Contex
 	return interceptor(ctx, in, info, handler)
 }
 
+func _TransactionService_ListTransactions_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListTransactionsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(TransactionServiceServer).ListTransactions(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: TransactionService_ListTransactions_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(TransactionServiceServer).ListTransactions(ctx, req.(*ListTransactionsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // TransactionService_ServiceDesc is the grpc.ServiceDesc for TransactionService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -120,6 +156,10 @@ var TransactionService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "HealthCheck",
 			Handler:    _TransactionService_HealthCheck_Handler,
+		},
+		{
+			MethodName: "ListTransactions",
+			Handler:    _TransactionService_ListTransactions_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/services/transaction/proto/transaction.proto
+++ b/services/transaction/proto/transaction.proto
@@ -2,7 +2,65 @@ syntax = "proto3";
 
 package transaction.v1;
 
+import "google/protobuf/timestamp.proto";
+
 option go_package = "github.com/boykush/foresee/services/transaction/gen/go/transaction/v1;transactionv1";
+
+// Category represents the category of a transaction
+enum Category {
+  CATEGORY_UNSPECIFIED = 0;
+  CATEGORY_INCOME = 1;               // Income
+  CATEGORY_FOOD = 2;                 // Food
+  CATEGORY_DAILY_NECESSITIES = 3;   // Daily necessities
+  CATEGORY_HOBBY = 4;                // Hobby & Entertainment
+  CATEGORY_SOCIAL = 5;               // Social expenses
+  CATEGORY_TRANSPORTATION = 6;       // Transportation
+  CATEGORY_CLOTHING = 7;             // Clothing & Beauty
+  CATEGORY_HEALTH = 8;               // Health & Medical
+  CATEGORY_AUTOMOBILE = 9;           // Automobile
+  CATEGORY_EDUCATION = 10;           // Education
+  CATEGORY_SPECIAL = 11;             // Special expenses
+  CATEGORY_CASH_CARD = 12;           // Cash & Card
+  CATEGORY_UTILITIES = 13;           // Utilities
+  CATEGORY_COMMUNICATION = 14;       // Communication
+  CATEGORY_HOUSING = 15;             // Housing
+  CATEGORY_TAX_SOCIAL_SECURITY = 16; // Tax & Social security
+  CATEGORY_INSURANCE = 17;           // Insurance
+  CATEGORY_OTHER = 18;               // Other
+}
+
+// Money represents an amount of money with currency-agnostic precision
+message Money {
+  // The whole units of the amount
+  int64 units = 1;
+  // Number of nano units of the amount (10^-9)
+  // Must be between -999,999,999 and +999,999,999 inclusive
+  // Sign must match units (both positive, both negative, or both zero)
+  int32 nanos = 2;
+}
+
+// Transaction represents a single financial transaction
+message Transaction {
+  // Unique identifier for the transaction
+  string id = 1;
+  // Date of the transaction
+  google.protobuf.Timestamp date = 2;
+  // Title or description of the transaction
+  string title = 3;
+  // Amount of the transaction (negative for expenses, positive for income)
+  Money amount = 4;
+  // Category of the transaction
+  Category category = 5;
+}
+
+// ListTransactionsRequest is the request for listing transactions
+message ListTransactionsRequest {}
+
+// ListTransactionsResponse is the response for listing transactions
+message ListTransactionsResponse {
+  // List of transactions
+  repeated Transaction transactions = 1;
+}
 
 // HealthCheckRequest is the request for health check
 message HealthCheckRequest {
@@ -24,4 +82,6 @@ message HealthCheckResponse {
 service TransactionService {
   // HealthCheck checks if the service is healthy
   rpc HealthCheck(HealthCheckRequest) returns (HealthCheckResponse);
+  // ListTransactions returns a list of all transactions
+  rpc ListTransactions(ListTransactionsRequest) returns (ListTransactionsResponse);
 }


### PR DESCRIPTION
## Summary
- Add `Category` enum with 18 transaction categories (Income, Food, Daily necessities, etc.)
- Add `Money` message for currency-agnostic amount representation (units + nanos, Google Money pattern)
- Add `Transaction` message with id, date (Timestamp), title, amount (Money), and category
- Add `ListTransactions` RPC to TransactionService

## Test plan
- [x] `buf generate` succeeds
- [x] `go build ./...` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)